### PR TITLE
upgrade to iroh 0.20.0

### DIFF
--- a/iroh-dag-sync/Cargo.toml
+++ b/iroh-dag-sync/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-iroh-blobs = { git = "https://github.com/n0-computer/iroh", branch = "main" }
-iroh-net = { git = "https://github.com/n0-computer/iroh", branch = "main" }
+iroh-blobs = "0.20.0"
+iroh-net = "0.20.0"
 iroh-car = "0.4.0"
 libipld = "0.16.0"
 redb = "2.1.1"

--- a/iroh-dag-sync/Cargo.toml
+++ b/iroh-dag-sync/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-iroh-blobs = "0.19.0"
-iroh-net = "0.19.0"
+iroh-blobs = { git = "https://github.com/n0-computer/iroh", branch = "main" }
+iroh-net = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-car = "0.4.0"
 libipld = "0.16.0"
 redb = "2.1.1"
 clap = { version = "4.5.7", features = ["derive"] }
 tracing-subscriber = "0.3.18"
 anyhow = "1.0.86"
-iroh-gossip = "0.19.0"
+iroh-gossip = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 tokio = { version = "1.38.0", features = ["full"] }
 postcard = "1.0.8"
 serde = "1.0.203"

--- a/iroh-dag-sync/Cargo.toml
+++ b/iroh-dag-sync/Cargo.toml
@@ -12,7 +12,7 @@ redb = "2.1.1"
 clap = { version = "4.5.7", features = ["derive"] }
 tracing-subscriber = "0.3.18"
 anyhow = "1.0.86"
-iroh-gossip = { git = "https://github.com/n0-computer/iroh", branch = "main" }
+iroh-gossip = "0.20.0"
 tokio = { version = "1.38.0", features = ["full"] }
 postcard = "1.0.8"
 serde = "1.0.203"

--- a/iroh-dag-sync/src/main.rs
+++ b/iroh-dag-sync/src/main.rs
@@ -7,7 +7,7 @@ use iroh_blobs::store::{Map, MapEntry};
 use iroh_blobs::{store::Store, BlobFormat};
 use iroh_car::CarReader;
 use iroh_io::AsyncSliceReaderExt;
-use iroh_net::discovery::{dns::DnsDiscovery, pkarr_publish::PkarrPublisher, ConcurrentDiscovery};
+use iroh_net::discovery::{dns::DnsDiscovery, pkarr::PkarrPublisher, ConcurrentDiscovery};
 use iroh_net::ticket::NodeTicket;
 use iroh_net::NodeAddr;
 use libipld::{cbor::DagCborCodec, codec::Codec};

--- a/iroh-dag-sync/src/main.rs
+++ b/iroh-dag-sync/src/main.rs
@@ -239,7 +239,7 @@ where
                                               // block_bytes.extend_from_slice(&cid.hash().digest()); // hash
         block_bytes.extend_from_slice(&data);
         let size: u64 = block_bytes.len() as u64;
-        file.write_all(&postcard::to_slice(&size, &mut buffer)?)
+        file.write_all(postcard::to_slice(&size, &mut buffer)?)
             .await?;
         file.write_all(&block_bytes).await?;
     }

--- a/iroh-dag-sync/src/protocol.rs
+++ b/iroh-dag-sync/src/protocol.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, ops::Deref, str::FromStr};
+use std::{collections::BTreeSet, fmt::Display, ops::Deref, str::FromStr};
 
 use iroh_blobs::Hash;
 use libipld::DagCbor;
@@ -224,9 +224,10 @@ pub fn ron_parser() -> ::ron::Options {
         .with_default_extension(ron::extensions::Extensions::UNWRAP_VARIANT_NEWTYPES)
 }
 
-impl ToString for TraversalOpts {
-    fn to_string(&self) -> String {
-        ron_parser().to_string(self).unwrap()
+impl Display for TraversalOpts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let res = ron_parser().to_string(self).unwrap();
+        write!(f, "{}", res)
     }
 }
 
@@ -242,7 +243,7 @@ impl TraversalOpts {
     pub fn from_args(root: &Option<Cid>, traversal: &Option<String>) -> anyhow::Result<Self> {
         match (root, traversal) {
             (Some(root), None) => Ok(TraversalOpts::Full(FullTraversalOpts {
-                root: root.clone(),
+                root: *root,
                 visited: Default::default(),
                 order: Default::default(),
                 filter: Default::default(),

--- a/iroh-dag-sync/src/sync.rs
+++ b/iroh-dag-sync/src/sync.rs
@@ -77,13 +77,8 @@ where
             send.0
                 .write_all(&SyncResponseHeader::Data(hash).as_bytes())
                 .await?;
-            send_blob::<iroh_blobs::store::fs::Store, _>(
-                &blobs,
-                hash,
-                &RangeSpec::all(),
-                &mut send,
-            )
-            .await?;
+            send_blob::<iroh_blobs::store::fs::Store, _>(blobs, hash, &RangeSpec::all(), &mut send)
+                .await?;
         } else {
             send.0
                 .write_all(&SyncResponseHeader::Hash(hash).as_bytes())

--- a/iroh-dag-sync/src/traversal.rs
+++ b/iroh-dag-sync/src/traversal.rs
@@ -147,8 +147,7 @@ pub struct FullTraversal<D> {
 
 impl<D> FullTraversal<D> {
     pub fn new(db: D, root: Cid, visited: HashSet<Cid>) -> Self {
-        let mut stack = Vec::new();
-        stack.push(root);
+        let stack = vec![root];
         Self {
             stack,
             visited,
@@ -214,7 +213,7 @@ pub fn get_traversal<'a, D: ReadableTables + Unpin + 'a>(
         }) => {
             let visited = visited.unwrap_or_default();
             let filter = filter.unwrap_or_default();
-            let traversal = FullTraversal::new(db, root.clone(), visited.into_iter().collect());
+            let traversal = FullTraversal::new(db, root, visited.into_iter().collect());
             match filter {
                 TraversalFilter::All => traversal.boxed(),
                 TraversalFilter::NoRaw => traversal.filter(|cid| cid.codec() != 0x55).boxed(),
@@ -230,7 +229,9 @@ pub fn get_traversal<'a, D: ReadableTables + Unpin + 'a>(
     })
 }
 
-pub fn get_inline(inline: InlineOpts) -> anyhow::Result<Box<dyn Fn(&Cid) -> bool>> {
+pub type InlineCb = Box<dyn Fn(&Cid) -> bool>;
+
+pub fn get_inline(inline: InlineOpts) -> anyhow::Result<InlineCb> {
     Ok(match inline {
         InlineOpts::All => Box::new(|_| true),
         InlineOpts::NoRaw => Box::new(|cid| cid.codec() != 0x55),

--- a/iroh-s3-bao-store/Cargo.toml
+++ b/iroh-s3-bao-store/Cargo.toml
@@ -21,7 +21,7 @@ flume = "0.11.0"
 futures-lite = "2.3"
 hex = "0.4.3"
 indicatif = "0.17.7"
-iroh = "0.19"
+iroh = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-io = { version = "0.6.0", features = ["x-http"] }
 num_cpus = "1.16.0"
 rand = "0.8.5"

--- a/iroh-s3-bao-store/Cargo.toml
+++ b/iroh-s3-bao-store/Cargo.toml
@@ -21,7 +21,7 @@ flume = "0.11.0"
 futures-lite = "2.3"
 hex = "0.4.3"
 indicatif = "0.17.7"
-iroh = { git = "https://github.com/n0-computer/iroh", branch = "main" }
+iroh = "0.20.0"
 iroh-io = { version = "0.6.0", features = ["x-http"] }
 num_cpus = "1.16.0"
 rand = "0.8.5"


### PR DESCRIPTION
needs `iroh-pkarr-node-discovery` from `iroh-examples` to be published to the latest version
Then `content-discovery` and `iroh-pkarr-naming-system` can be updated