### PR TITLE
deps(content-discovery): upgrade to 0.22

### DIFF
--- a/content-discovery/Cargo.toml
+++ b/content-discovery/Cargo.toml
@@ -26,6 +26,6 @@ missing_debug_implementations = "warn"
 unused-async = "warn"
 
 [workspace.dependencies]
-iroh-net = "0.21"
-iroh-blobs = "0.21"
-iroh-base = "0.21"
+iroh-net = "0.22"
+iroh-blobs = "0.22"
+iroh-base = "0.22"

--- a/content-discovery/iroh-mainline-tracker/Cargo.toml
+++ b/content-discovery/iroh-mainline-tracker/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4.3"
 humantime = "2.1.0"
 iroh-net = { workspace = true }
 iroh-blobs = { workspace = true }
-iroh-pkarr-node-discovery = "0.5"
+iroh-pkarr-node-discovery = "0.6"
 mainline = { version = "2.0.0", features = ["async"] }
 pkarr = { version = "1.0.1", features = ["async"] }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std"] }


### PR DESCRIPTION
`iroh-mainline-tracker` fails to build as it depends on `iroh-pkarr-node-discovery@0.5`, which pulls in `iroh-net@0.21`.