### PR TITLE
chore: upgrade to iroh v0.22.0

### DIFF
--- a/iroh-dag-sync/Cargo.toml
+++ b/iroh-dag-sync/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-iroh-blobs = "0.21"
-iroh-gossip = "0.21"
-iroh-net = "0.21"
+iroh-blobs = "0.22"
+iroh-gossip = "0.22"
+iroh-net = "0.22"
 iroh-car = "0.4.0"
 libipld = "0.16.0"
 redb = "2.1.1"

--- a/iroh-pkarr-naming-system/Cargo.toml
+++ b/iroh-pkarr-naming-system/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.79"
 derive_more = "0.99.17"
-iroh = "0.21"
-iroh-blobs = "0.21"
-iroh-net = "0.21"
+iroh = "0.22"
+iroh-blobs = "0.22"
+iroh-net = "0.22"
 pkarr = { version = "1.0.1", features = ["async", "dht"] }
 tokio = "1.35.1"
 tracing = "0.1.40"

--- a/iroh-s3-bao-store/Cargo.toml
+++ b/iroh-s3-bao-store/Cargo.toml
@@ -21,7 +21,7 @@ flume = "0.11.0"
 futures-lite = "2.3"
 hex = "0.4.3"
 indicatif = "0.17.7"
-iroh = "0.21"
+iroh = "0.22"
 iroh-io = { version = "0.6.0", features = ["x-http"] }
 num_cpus = "1.16.0"
 rand = "0.8.5"


### PR DESCRIPTION
upgrades `iroh-dag-sync`, `iroh-pkarr-naming-system`, and `iroh-s3-bao-store`