### PR TITLE
The HTTP/3 protocol on iroh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   MSRV: "1.75"
-  RS_EXAMPLES_LIST: "content-discovery,iroh-pkarr-naming-system,iroh-s3-bao-store,iroh-dag-sync"
+  RS_EXAMPLES_LIST: "content-discovery,iroh-pkarr-naming-system,iroh-s3-bao-store,iroh-dag-sync,h3-iroh"
   IROH_FORCE_STAGING_RELAYS: "1"
 
 jobs:

--- a/h3-iroh/Cargo.toml
+++ b/h3-iroh/Cargo.toml
@@ -15,7 +15,7 @@ http-body = { version = "1", optional = true }
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.5", optional = true }
 hyper-util = { version = "0.1", optional = true }
-iroh-net = "0.27"
+iroh-net = { git = "http://github.com/n0-computer/iroh/", branch = "main" }
 tokio = { version = "1", features = ["io-util"], default-features = false}
 tokio-util = "0.7"
 tower = { version = "0.5", optional = true }
@@ -32,9 +32,6 @@ axum = [
      "dep:hyper-util",
      "dep:tower",
 ]
-
-[patch.crates-io]
-iroh-net = { git = "http://github.com/n0-computer/iroh/", branch = "main" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/h3-iroh/Cargo.toml
+++ b/h3-iroh/Cargo.toml
@@ -34,7 +34,7 @@ axum = [
 ]
 
 [patch.crates-io]
-iroh-net = { path = "../../iroh/iroh-net" }
+iroh-net = { git = "http://github.com/n0-computer/iroh/", branch = "main" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/h3-iroh/Cargo.toml
+++ b/h3-iroh/Cargo.toml
@@ -5,13 +5,33 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
+anyhow = { version = "1", optional = true }
+axum = { version = "0.7", optional = true }
 bytes = "1"
 futures = "0.3"
 h3 = { version = "0.0.6", features = ["tracing"] }
-iroh-net = "0.26"
+http = { version =  "1.1", optional = true }
+http-body = { version = "1", optional = true }
+http-body-util = { version = "0.1", optional = true }
+hyper = { version = "1.5", optional = true }
+hyper-util = { version = "0.1", optional = true }
+iroh-net = "0.27"
 tokio = { version = "1", features = ["io-util"], default-features = false}
 tokio-util = "0.7"
+tower = { version = "0.5", optional = true }
 tracing = "0.1"
+
+[features]
+axum = [
+     "dep:anyhow",
+     "dep:axum",
+     "dep:http",
+     "dep:http-body",
+     "dep:http-body-util",
+     "dep:hyper",
+     "dep:hyper-util",
+     "dep:tower",
+]
 
 [patch.crates-io]
 iroh-net = { path = "../../iroh/iroh-net" }

--- a/h3-iroh/Cargo.toml
+++ b/h3-iroh/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "h3-iroh"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+bytes = "1"
+futures = "0.3"
+h3 = { version = "0.0.6", features = ["tracing"] }
+iroh-net = "0.26"
+tokio = { version = "1", features = ["io-util"], default-features = false}
+tokio-util = "0.7"
+tracing = "0.1"
+
+[patch.crates-io]
+iroh-net = { path = "../../iroh/iroh-net" }
+
+[dev-dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+http = "1"
+tracing-subscriber = "0.3"

--- a/h3-iroh/examples/client.rs
+++ b/h3-iroh/examples/client.rs
@@ -1,0 +1,82 @@
+use std::future;
+use std::str::FromStr;
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use iroh_net::ticket::NodeTicket;
+use iroh_net::NodeAddr;
+use tokio::io::AsyncWriteExt;
+use tracing::info;
+
+#[derive(Parser, Debug)]
+#[command()]
+struct Args {
+    #[arg(long, help = "Use SSLKEYLOGFILE environment variable to log TLS keys")]
+    keylogfile: bool,
+    #[arg()]
+    uri: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let args = Args::parse();
+
+    let uri: http::Uri = args.uri.parse()?;
+    if uri.scheme_str() != Some("iroh+h3") {
+        bail!("URI scheme must be iroh+h3");
+    }
+    let ticket = uri.host().context("missing hostname in URI")?;
+    let ticket = NodeTicket::from_str(&ticket)?;
+    let addr: NodeAddr = ticket.into();
+
+    let ep = iroh_net::Endpoint::builder()
+        .keylog(args.keylogfile)
+        .bind()
+        .await?;
+
+    let conn = ep.connect(addr, b"iroh+h3").await?;
+    let conn = h3_iroh::Connection::new(conn);
+
+    let (mut driver, mut send_request) = h3::client::new(conn).await?;
+
+    let drive_fut = async move {
+        future::poll_fn(|cx| driver.poll_close(cx)).await?;
+        Ok::<(), anyhow::Error>(())
+    };
+
+    let req_fut = async move {
+        info!("sending request");
+        let req = http::Request::builder().uri(uri).body(())?;
+        let mut stream = send_request.send_request(req).await?;
+        stream.finish().await?;
+
+        info!("receiving response");
+        let resp = stream.recv_response().await?;
+        info!(
+            version = ?resp.version(),
+            status = ?resp.status(),
+            headers = ?resp.headers(),
+            "response",
+        );
+        while let Some(mut chunk) = stream.recv_data().await? {
+            info!("chunk!");
+            let mut out = tokio::io::stdout();
+            out.write_all_buf(&mut chunk).await?;
+            out.flush().await?;
+        }
+
+        Ok::<(), anyhow::Error>(())
+    };
+
+    let (req_res, drive_res) = tokio::join!(req_fut, drive_fut);
+    req_res?;
+    drive_res?;
+
+    info!("closing ep");
+    ep.close(1u8.into(), b"ep closing").await?;
+    info!("ep closed");
+
+    Ok(())
+}

--- a/h3-iroh/examples/client.rs
+++ b/h3-iroh/examples/client.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         bail!("URI scheme must be iroh+h3");
     }
     let ticket = uri.host().context("missing hostname in URI")?;
-    let ticket = NodeTicket::from_str(&ticket)?;
+    let ticket = NodeTicket::from_str(ticket)?;
     let addr: NodeAddr = ticket.into();
 
     let ep = iroh_net::Endpoint::builder()

--- a/h3-iroh/examples/server-axum.rs
+++ b/h3-iroh/examples/server-axum.rs
@@ -1,0 +1,39 @@
+//! Demonstration of an axum server serving h3 over iroh
+//!
+//! run using `cargo run --features axum --example server-axum`
+
+use anyhow::Result;
+use axum::response::Html;
+use axum::routing::get;
+use axum::Router;
+use futures::StreamExt;
+use iroh_net::ticket::NodeTicket;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let app = Router::new().route("/", get(handler));
+
+    let ep = iroh_net::Endpoint::builder()
+        .alpns(vec![b"iroh+h3".to_vec()])
+        .bind()
+        .await?;
+    info!("accepting connections on node: {}", ep.node_id());
+
+    // Wait for direct addresses and a RelayUrl before printing a NodeTicket.
+    ep.direct_addresses().next().await;
+    ep.watch_home_relay().next().await;
+    let ticket = NodeTicket::new(ep.node_addr().await?);
+    info!("node ticket: {ticket}");
+    info!("run: cargo run --example client -- iroh+h3://{ticket}/");
+
+    h3_iroh::axum::serve(ep, app).await?;
+
+    Ok(())
+}
+
+async fn handler() -> Html<&'static str> {
+    Html("<h1>Hello, World!</h1>")
+}

--- a/h3-iroh/examples/server.rs
+++ b/h3-iroh/examples/server.rs
@@ -1,0 +1,153 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use bytes::{Bytes, BytesMut};
+use clap::Parser;
+use futures::StreamExt;
+use h3::error::ErrorLevel;
+use h3::quic::BidiStream;
+use h3::server::RequestStream;
+use http::{Request, StatusCode};
+use iroh_net::endpoint::{self, Incoming};
+use iroh_net::ticket::NodeTicket;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+use tracing::{debug, error, field, info, info_span, Instrument, Span};
+
+#[derive(Parser, Debug)]
+#[command()]
+struct Args {
+    #[arg(
+        short,
+        long,
+        name = "DIR",
+        help = "Root directory to server files from, if omitted server will only respond OK"
+    )]
+    root: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let args = Args::parse();
+
+    let root = if let Some(root) = args.root {
+        if !root.is_dir() {
+            bail!("{}: is not a readable directory", root.display());
+        } else {
+            info!("serving {}", root.display());
+            Arc::new(Some(root))
+        }
+    } else {
+        Arc::new(None)
+    };
+
+    let ep = iroh_net::Endpoint::builder()
+        .alpns(vec![b"iroh+h3".to_vec()])
+        .bind()
+        .await?;
+    info!("accepting connections on node: {}", ep.node_id());
+
+    // Wait for direct addresses and a RelayUrl before printing a NodeTicket.
+    ep.direct_addresses().next().await;
+    ep.watch_home_relay().next().await;
+    info!("node ticket: {}", NodeTicket::new(ep.node_addr().await?));
+
+    // Handle incoming connections
+    while let Some(incoming) = ep.accept().await {
+        tokio::spawn({
+            let root = root.clone();
+            async move {
+                if let Err(err) = handle_connection(incoming, root).await {
+                    error!("failed connection: {err:#}");
+                }
+            }
+            .instrument(info_span!("conn", remote_node_id = field::Empty))
+        });
+    }
+    ep.close(1u8.into(), b"ep closing").await?;
+
+    Ok(())
+}
+
+async fn handle_connection(incoming: Incoming, root: Arc<Option<PathBuf>>) -> Result<()> {
+    let conn = incoming.accept()?.await?;
+    let remote_node_id = endpoint::get_remote_node_id(&conn)?;
+    let span = Span::current();
+    span.record("remote_node_id", remote_node_id.fmt_short());
+    info!("new connection");
+
+    let mut h3_conn = h3::server::Connection::new(h3_iroh::Connection::new(conn)).await?;
+    loop {
+        match h3_conn.accept().await {
+            Ok(Some((req, stream))) => {
+                info!(?req, "new request");
+                tokio::spawn({
+                    let root = root.clone();
+                    async move {
+                        if let Err(err) = handle_request(req, stream, root).await {
+                            error!("request failed: {err:#}");
+                        }
+                    }
+                    .instrument(info_span!("req"))
+                });
+            }
+            Ok(None) => {
+                break;
+            }
+            Err(err) => {
+                error!("accept error: {err:#}");
+                match err.get_error_level() {
+                    ErrorLevel::ConnectionError => break,
+                    ErrorLevel::StreamError => continue,
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_request<T>(
+    req: Request<()>,
+    mut stream: RequestStream<T, Bytes>,
+    serve_root: Arc<Option<PathBuf>>,
+) -> Result<()>
+where
+    T: BidiStream<Bytes>,
+{
+    let (status, file) = match serve_root.as_deref() {
+        None => (StatusCode::OK, None),
+        Some(_) if req.uri().path().contains("..") => (StatusCode::NOT_FOUND, None),
+        Some(root) => {
+            let path = root.join(req.uri().path().strip_prefix('/').unwrap_or(""));
+            debug!(path = %path.display(), "Opening file");
+            match File::open(&path).await {
+                Ok(file) => (StatusCode::OK, Some(file)),
+                Err(err) => {
+                    error!(path = %path.to_string_lossy(), "failed to open file: {err:#}");
+                    (StatusCode::NOT_FOUND, None)
+                }
+            }
+        }
+    };
+
+    let resp = http::Response::builder().status(status).body(())?;
+    match stream.send_response(resp).await {
+        Ok(_) => info!("success"),
+        Err(err) => error!("unable to send response: {err:#}"),
+    }
+    if let Some(mut file) = file {
+        loop {
+            let mut buf = BytesMut::with_capacity(4096 * 10);
+            if file.read_buf(&mut buf).await? == 0 {
+                break;
+            }
+            stream.send_data(buf.freeze()).await?;
+        }
+    }
+    stream.finish().await?;
+    Ok(())
+}

--- a/h3-iroh/examples/server.rs
+++ b/h3-iroh/examples/server.rs
@@ -1,3 +1,7 @@
+//! Demonstration of using h3-iroh as a server without framework.
+//!
+//! run using `cargo run --example server -- --root .`
+
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -53,7 +57,9 @@ async fn main() -> Result<()> {
     // Wait for direct addresses and a RelayUrl before printing a NodeTicket.
     ep.direct_addresses().next().await;
     ep.watch_home_relay().next().await;
-    info!("node ticket: {}", NodeTicket::new(ep.node_addr().await?));
+    let ticket = NodeTicket::new(ep.node_addr().await?);
+    info!("node ticket: {ticket}");
+    info!("run e.g.: cargo run --example client -- iroh+h3://{ticket}/Cargo.toml");
 
     // Handle incoming connections
     while let Some(incoming) = ep.accept().await {

--- a/h3-iroh/src/axum.rs
+++ b/h3-iroh/src/axum.rs
@@ -1,0 +1,127 @@
+//! Support for an axum server.
+
+use anyhow::Result;
+use axum::Router;
+use bytes::{Buf, Bytes};
+use http::{Request, Response, Version};
+use iroh_net::Endpoint;
+use tracing::{debug, error, info_span, trace, warn, Instrument};
+
+use h3::{error::ErrorLevel, quic::BidiStream, server::RequestStream};
+use http_body_util::BodyExt;
+use tower::Service;
+
+static ALPN: &[u8] = b"iroh+h3";
+
+/// Serves an axum router over iroh using the h3 protocol.
+///
+/// This implementation is not production ready.  E.g. it copies the entire requests and
+/// responses in memory.  It serves more as an example.
+pub async fn serve(endpoint: Endpoint, router: axum::Router) -> Result<()> {
+    endpoint.set_alpns(vec![ALPN.to_vec()])?;
+    while let Some(incoming) = endpoint.accept().await {
+        trace!("accepting connection");
+        let router = router.clone();
+        tokio::spawn(
+            async move {
+                if let Err(err) = handle_connection(incoming, router).await {
+                    warn!("error accepting connection: {err:#}");
+                }
+            }
+            .instrument(info_span!("h3-connection")),
+        );
+    }
+    endpoint.close(0u8.into(), b"server exiting").await?;
+    Ok(())
+}
+
+async fn handle_connection(incoming: iroh_net::endpoint::Incoming, router: Router) -> Result<()> {
+    debug!("new connection established");
+    let conn = incoming.await?;
+    let conn = crate::Connection::new(conn);
+    let mut conn = h3::server::Connection::new(conn).await?;
+    loop {
+        match conn.accept().await {
+            Ok(Some((req, stream))) => {
+                let router = router.clone();
+                tokio::spawn(
+                    async move {
+                        if let Err(err) = handle_request(req, stream, router.clone()).await {
+                            warn!("handling request failed: {err}");
+                        }
+                    }
+                    .instrument(info_span!("h3-request")),
+                );
+            }
+            Ok(None) => {
+                break; // No more streams to be recieved
+            }
+
+            Err(err) => {
+                error!("accept error: {err}");
+                match err.get_error_level() {
+                    ErrorLevel::ConnectionError => break,
+                    ErrorLevel::StreamError => continue,
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Handles a single request, buffering the entire request.
+async fn handle_request<T>(
+    req: Request<()>,
+    mut stream: RequestStream<T, Bytes>,
+    mut tower_service: Router,
+) -> Result<()>
+where
+    T: BidiStream<Bytes>,
+{
+    debug!("new request: {:#?}", req);
+    // TODO: All this copying is no good.
+    let mut body = vec![];
+    while let Ok(Some(data)) = stream.recv_data().await {
+        body.extend_from_slice(data.chunk());
+    }
+    let body = http_body_util::Full::new(Bytes::from(body));
+
+    let mut builder = axum::extract::Request::builder()
+        .version(req.version())
+        .uri(req.uri())
+        .method(req.method());
+    *builder.headers_mut().expect("builder invariant") = req.headers().clone();
+    let req = builder.body(body)?;
+
+    // Call Service
+    let res = tower_service.call(req).await?;
+
+    let mut builder = Response::builder()
+        .status(res.status())
+        .version(Version::HTTP_3);
+    *builder.headers_mut().expect("builder invariant") = res.headers().clone();
+    let response = builder.body(())?;
+
+    stream.send_response(response).await.unwrap();
+
+    // send response body and trailers
+    let mut buf = res.into_body().into_data_stream();
+    while let Some(chunk) = buf.frame().await {
+        match chunk {
+            Ok(frame) => {
+                if frame.is_data() {
+                    let data = frame.into_data().unwrap();
+                    stream.send_data(data).await.unwrap();
+                } else if frame.is_trailers() {
+                    let trailers = frame.into_trailers().unwrap();
+                    stream.send_trailers(trailers).await.unwrap();
+                }
+            }
+            Err(err) => {
+                warn!("Failed to read frame from response body stream: {err:#}");
+            }
+        }
+    }
+    trace!("done");
+    Ok(stream.finish().await?)
+}

--- a/h3-iroh/src/lib.rs
+++ b/h3-iroh/src/lib.rs
@@ -20,6 +20,9 @@ use tracing::instrument;
 
 pub use iroh_net::endpoint::{AcceptBi, AcceptUni, Endpoint, OpenBi, OpenUni, VarInt, WriteError};
 
+#[cfg(feature = "axum")]
+pub mod axum;
+
 /// BoxStream with Sync trait
 type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Sync + Send + 'a>>;
 

--- a/h3-iroh/src/lib.rs
+++ b/h3-iroh/src/lib.rs
@@ -1,0 +1,746 @@
+//! QUIC Transport implementation with Quinn
+//!
+//! This module implements QUIC traits with Quinn.
+#![deny(missing_docs)]
+
+use std::convert::TryInto;
+use std::fmt::{self, Display};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{self, Poll};
+
+use bytes::{Buf, Bytes, BytesMut};
+use futures::{ready, stream, Stream, StreamExt};
+use h3::ext::Datagram;
+use h3::quic::{self, Error, StreamId, WriteBuf};
+use iroh_net::endpoint::{self, ApplicationClose, ClosedStream, ReadDatagram};
+use tokio_util::sync::ReusableBoxFuture;
+use tracing::instrument;
+
+pub use iroh_net::endpoint::{AcceptBi, AcceptUni, Endpoint, OpenBi, OpenUni, VarInt, WriteError};
+
+/// BoxStream with Sync trait
+type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Sync + Send + 'a>>;
+
+/// A QUIC connection backed by Quinn
+///
+/// Implements a [`quic::Connection`] backed by a [`endpoint::Connection`].
+pub struct Connection {
+    conn: iroh_net::endpoint::Connection,
+    incoming_bi: BoxStreamSync<'static, <AcceptBi<'static> as Future>::Output>,
+    opening_bi: Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+    incoming_uni: BoxStreamSync<'static, <AcceptUni<'static> as Future>::Output>,
+    opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
+    datagrams: BoxStreamSync<'static, <ReadDatagram<'static> as Future>::Output>,
+}
+
+impl Connection {
+    /// Create a [`Connection`] from a [`endpoint::Connection`]
+    pub fn new(conn: iroh_net::endpoint::Connection) -> Self {
+        Self {
+            conn: conn.clone(),
+            incoming_bi: Box::pin(stream::unfold(conn.clone(), |conn| async {
+                Some((conn.accept_bi().await, conn))
+            })),
+            opening_bi: None,
+            incoming_uni: Box::pin(stream::unfold(conn.clone(), |conn| async {
+                Some((conn.accept_uni().await, conn))
+            })),
+            opening_uni: None,
+            datagrams: Box::pin(stream::unfold(conn, |conn| async {
+                Some((conn.read_datagram().await, conn))
+            })),
+        }
+    }
+}
+
+/// The error type for [`Connection`]
+///
+/// Wraps reasons a Quinn connection might be lost.
+#[derive(Debug)]
+pub struct ConnectionError(endpoint::ConnectionError);
+
+impl std::error::Error for ConnectionError {}
+
+impl fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for ConnectionError {
+    fn is_timeout(&self) -> bool {
+        matches!(self.0, endpoint::ConnectionError::TimedOut)
+    }
+
+    fn err_code(&self) -> Option<u64> {
+        match self.0 {
+            endpoint::ConnectionError::ApplicationClosed(ApplicationClose {
+                error_code, ..
+            }) => Some(error_code.into_inner()),
+            _ => None,
+        }
+    }
+}
+
+impl From<endpoint::ConnectionError> for ConnectionError {
+    fn from(e: endpoint::ConnectionError) -> Self {
+        Self(e)
+    }
+}
+
+/// Types of errors when sending a datagram.
+#[derive(Debug)]
+pub enum SendDatagramError {
+    /// Datagrams are not supported by the peer
+    UnsupportedByPeer,
+    /// Datagrams are locally disabled
+    Disabled,
+    /// The datagram was too large to be sent.
+    TooLarge,
+    /// Network error
+    ConnectionLost(Box<dyn Error>),
+}
+
+impl fmt::Display for SendDatagramError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SendDatagramError::UnsupportedByPeer => write!(f, "datagrams not supported by peer"),
+            SendDatagramError::Disabled => write!(f, "datagram support disabled"),
+            SendDatagramError::TooLarge => write!(f, "datagram too large"),
+            SendDatagramError::ConnectionLost(_) => write!(f, "connection lost"),
+        }
+    }
+}
+
+impl std::error::Error for SendDatagramError {}
+
+impl Error for SendDatagramError {
+    fn is_timeout(&self) -> bool {
+        false
+    }
+
+    fn err_code(&self) -> Option<u64> {
+        match self {
+            Self::ConnectionLost(err) => err.err_code(),
+            _ => None,
+        }
+    }
+}
+
+impl From<endpoint::SendDatagramError> for SendDatagramError {
+    fn from(value: endpoint::SendDatagramError) -> Self {
+        match value {
+            endpoint::SendDatagramError::UnsupportedByPeer => Self::UnsupportedByPeer,
+            endpoint::SendDatagramError::Disabled => Self::Disabled,
+            endpoint::SendDatagramError::TooLarge => Self::TooLarge,
+            endpoint::SendDatagramError::ConnectionLost(err) => {
+                Self::ConnectionLost(ConnectionError::from(err).into())
+            }
+        }
+    }
+}
+
+impl<B> quic::Connection<B> for Connection
+where
+    B: Buf,
+{
+    type RecvStream = RecvStream;
+    type OpenStreams = OpenStreams;
+    type AcceptError = ConnectionError;
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_accept_bidi(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<Self::BidiStream>, Self::AcceptError>> {
+        let (send, recv) = match ready!(self.incoming_bi.poll_next_unpin(cx)) {
+            Some(x) => x?,
+            None => return Poll::Ready(Ok(None)),
+        };
+        Poll::Ready(Ok(Some(Self::BidiStream {
+            send: Self::SendStream::new(send),
+            recv: Self::RecvStream::new(recv),
+        })))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_accept_recv(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<Self::RecvStream>, Self::AcceptError>> {
+        let recv = match ready!(self.incoming_uni.poll_next_unpin(cx)) {
+            Some(x) => x?,
+            None => return Poll::Ready(Ok(None)),
+        };
+        Poll::Ready(Ok(Some(Self::RecvStream::new(recv))))
+    }
+
+    fn opener(&self) -> Self::OpenStreams {
+        OpenStreams {
+            conn: self.conn.clone(),
+            opening_bi: None,
+            opening_uni: None,
+        }
+    }
+}
+
+impl<B> quic::OpenStreams<B> for Connection
+where
+    B: Buf,
+{
+    type SendStream = SendStream<B>;
+    type BidiStream = BidiStream<B>;
+    type OpenError = ConnectionError;
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_open_bidi(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Self::BidiStream, Self::OpenError>> {
+        if self.opening_bi.is_none() {
+            self.opening_bi = Some(Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+                Some((conn.clone().open_bi().await, conn))
+            })));
+        }
+
+        let (send, recv) =
+            ready!(self.opening_bi.as_mut().unwrap().poll_next_unpin(cx)).unwrap()?;
+        Poll::Ready(Ok(Self::BidiStream {
+            send: Self::SendStream::new(send),
+            recv: RecvStream::new(recv),
+        }))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_open_send(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Self::SendStream, Self::OpenError>> {
+        if self.opening_uni.is_none() {
+            self.opening_uni = Some(Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+                Some((conn.open_uni().await, conn))
+            })));
+        }
+
+        let send = ready!(self.opening_uni.as_mut().unwrap().poll_next_unpin(cx)).unwrap()?;
+        Poll::Ready(Ok(Self::SendStream::new(send)))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn close(&mut self, code: h3::error::Code, reason: &[u8]) {
+        self.conn.close(
+            VarInt::from_u64(code.value()).expect("error code VarInt"),
+            reason,
+        );
+    }
+}
+
+impl<B> quic::SendDatagramExt<B> for Connection
+where
+    B: Buf,
+{
+    type Error = SendDatagramError;
+
+    #[instrument(skip_all, level = "trace")]
+    fn send_datagram(&mut self, data: Datagram<B>) -> Result<(), SendDatagramError> {
+        // TODO investigate static buffer from known max datagram size
+        let mut buf = BytesMut::new();
+        data.encode(&mut buf);
+        self.conn.send_datagram(buf.freeze())?;
+
+        Ok(())
+    }
+}
+
+impl quic::RecvDatagramExt for Connection {
+    type Buf = Bytes;
+
+    type Error = ConnectionError;
+
+    #[inline]
+    #[instrument(skip_all, level = "trace")]
+    fn poll_accept_datagram(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<Self::Buf>, Self::Error>> {
+        match ready!(self.datagrams.poll_next_unpin(cx)) {
+            Some(Ok(x)) => Poll::Ready(Ok(Some(x))),
+            Some(Err(e)) => Poll::Ready(Err(e.into())),
+            None => Poll::Ready(Ok(None)),
+        }
+    }
+}
+
+/// Stream opener backed by a Quinn connection
+///
+/// Implements [`quic::OpenStreams`] using [`endpoint::Connection`],
+/// [`endpoint::OpenBi`], [`endpoint::OpenUni`].
+pub struct OpenStreams {
+    conn: endpoint::Connection,
+    opening_bi: Option<BoxStreamSync<'static, <OpenBi<'static> as Future>::Output>>,
+    opening_uni: Option<BoxStreamSync<'static, <OpenUni<'static> as Future>::Output>>,
+}
+
+impl<B> quic::OpenStreams<B> for OpenStreams
+where
+    B: Buf,
+{
+    type SendStream = SendStream<B>;
+    type BidiStream = BidiStream<B>;
+    type OpenError = ConnectionError;
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_open_bidi(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Self::BidiStream, Self::OpenError>> {
+        if self.opening_bi.is_none() {
+            self.opening_bi = Some(Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+                Some((conn.open_bi().await, conn))
+            })));
+        }
+
+        let (send, recv) =
+            ready!(self.opening_bi.as_mut().unwrap().poll_next_unpin(cx)).unwrap()?;
+        Poll::Ready(Ok(Self::BidiStream {
+            send: Self::SendStream::new(send),
+            recv: RecvStream::new(recv),
+        }))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_open_send(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Self::SendStream, Self::OpenError>> {
+        if self.opening_uni.is_none() {
+            self.opening_uni = Some(Box::pin(stream::unfold(self.conn.clone(), |conn| async {
+                Some((conn.open_uni().await, conn))
+            })));
+        }
+
+        let send = ready!(self.opening_uni.as_mut().unwrap().poll_next_unpin(cx)).unwrap()?;
+        Poll::Ready(Ok(Self::SendStream::new(send)))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn close(&mut self, code: h3::error::Code, reason: &[u8]) {
+        self.conn.close(
+            VarInt::from_u64(code.value()).expect("error code VarInt"),
+            reason,
+        );
+    }
+}
+
+impl Clone for OpenStreams {
+    fn clone(&self) -> Self {
+        Self {
+            conn: self.conn.clone(),
+            opening_bi: None,
+            opening_uni: None,
+        }
+    }
+}
+
+/// Quinn-backed bidirectional stream
+///
+/// Implements [`quic::BidiStream`] which allows the stream to be split
+/// into two structs each implementing one direction.
+pub struct BidiStream<B>
+where
+    B: Buf,
+{
+    send: SendStream<B>,
+    recv: RecvStream,
+}
+
+impl<B> quic::BidiStream<B> for BidiStream<B>
+where
+    B: Buf,
+{
+    type SendStream = SendStream<B>;
+    type RecvStream = RecvStream;
+
+    fn split(self) -> (Self::SendStream, Self::RecvStream) {
+        (self.send, self.recv)
+    }
+}
+
+impl<B: Buf> quic::RecvStream for BidiStream<B> {
+    type Buf = Bytes;
+    type Error = ReadError;
+
+    fn poll_data(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<Self::Buf>, Self::Error>> {
+        self.recv.poll_data(cx)
+    }
+
+    fn stop_sending(&mut self, error_code: u64) {
+        self.recv.stop_sending(error_code)
+    }
+
+    fn recv_id(&self) -> StreamId {
+        self.recv.recv_id()
+    }
+}
+
+impl<B> quic::SendStream<B> for BidiStream<B>
+where
+    B: Buf,
+{
+    type Error = SendStreamError;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.send.poll_ready(cx)
+    }
+
+    fn poll_finish(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.send.poll_finish(cx)
+    }
+
+    fn reset(&mut self, reset_code: u64) {
+        self.send.reset(reset_code)
+    }
+
+    fn send_data<D: Into<WriteBuf<B>>>(&mut self, data: D) -> Result<(), Self::Error> {
+        self.send.send_data(data)
+    }
+
+    fn send_id(&self) -> StreamId {
+        self.send.send_id()
+    }
+}
+impl<B> quic::SendStreamUnframed<B> for BidiStream<B>
+where
+    B: Buf,
+{
+    fn poll_send<D: Buf>(
+        &mut self,
+        cx: &mut task::Context<'_>,
+        buf: &mut D,
+    ) -> Poll<Result<usize, Self::Error>> {
+        self.send.poll_send(cx, buf)
+    }
+}
+
+/// Quinn-backed receive stream
+///
+/// Implements a [`quic::RecvStream`] backed by a [`endpoint::RecvStream`].
+pub struct RecvStream {
+    stream: Option<endpoint::RecvStream>,
+    read_chunk_fut: ReadChunkFuture,
+}
+
+type ReadChunkFuture = ReusableBoxFuture<
+    'static,
+    (
+        endpoint::RecvStream,
+        Result<Option<endpoint::Chunk>, endpoint::ReadError>,
+    ),
+>;
+
+impl RecvStream {
+    fn new(stream: endpoint::RecvStream) -> Self {
+        Self {
+            stream: Some(stream),
+            // Should only allocate once the first time it's used
+            read_chunk_fut: ReusableBoxFuture::new(async { unreachable!() }),
+        }
+    }
+}
+
+impl quic::RecvStream for RecvStream {
+    type Buf = Bytes;
+    type Error = ReadError;
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_data(
+        &mut self,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<Option<Self::Buf>, Self::Error>> {
+        if let Some(mut stream) = self.stream.take() {
+            self.read_chunk_fut.set(async move {
+                let chunk = stream.read_chunk(usize::MAX, true).await;
+                (stream, chunk)
+            })
+        };
+
+        let (stream, chunk) = ready!(self.read_chunk_fut.poll(cx));
+        self.stream = Some(stream);
+        Poll::Ready(Ok(chunk?.map(|c| c.bytes)))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn stop_sending(&mut self, error_code: u64) {
+        self.stream
+            .as_mut()
+            .unwrap()
+            .stop(VarInt::from_u64(error_code).expect("invalid error_code"))
+            .ok();
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn recv_id(&self) -> StreamId {
+        self.stream
+            .as_ref()
+            .unwrap()
+            .id()
+            .0
+            .try_into()
+            .expect("invalid stream id")
+    }
+}
+
+/// The error type for [`RecvStream`]
+///
+/// Wraps errors that occur when reading from a receive stream.
+#[derive(Debug)]
+pub struct ReadError(endpoint::ReadError);
+
+impl From<ReadError> for std::io::Error {
+    fn from(value: ReadError) -> Self {
+        value.0.into()
+    }
+}
+
+impl std::error::Error for ReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl fmt::Display for ReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<ReadError> for Arc<dyn Error> {
+    fn from(e: ReadError) -> Self {
+        Arc::new(e)
+    }
+}
+
+impl From<endpoint::ReadError> for ReadError {
+    fn from(e: endpoint::ReadError) -> Self {
+        Self(e)
+    }
+}
+
+impl Error for ReadError {
+    fn is_timeout(&self) -> bool {
+        matches!(
+            self.0,
+            endpoint::ReadError::ConnectionLost(endpoint::ConnectionError::TimedOut)
+        )
+    }
+
+    fn err_code(&self) -> Option<u64> {
+        match self.0 {
+            endpoint::ReadError::ConnectionLost(endpoint::ConnectionError::ApplicationClosed(
+                ApplicationClose { error_code, .. },
+            )) => Some(error_code.into_inner()),
+            endpoint::ReadError::Reset(error_code) => Some(error_code.into_inner()),
+            _ => None,
+        }
+    }
+}
+
+/// Quinn-backed send stream
+///
+/// Implements a [`quic::SendStream`] backed by a [`endpoint::SendStream`].
+pub struct SendStream<B: Buf> {
+    stream: Option<endpoint::SendStream>,
+    writing: Option<WriteBuf<B>>,
+    write_fut: WriteFuture,
+}
+
+type WriteFuture =
+    ReusableBoxFuture<'static, (endpoint::SendStream, Result<usize, endpoint::WriteError>)>;
+
+impl<B> SendStream<B>
+where
+    B: Buf,
+{
+    fn new(stream: endpoint::SendStream) -> SendStream<B> {
+        Self {
+            stream: Some(stream),
+            writing: None,
+            write_fut: ReusableBoxFuture::new(async { unreachable!() }),
+        }
+    }
+}
+
+impl<B> quic::SendStream<B> for SendStream<B>
+where
+    B: Buf,
+{
+    type Error = SendStreamError;
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if let Some(ref mut data) = self.writing {
+            while data.has_remaining() {
+                if let Some(mut stream) = self.stream.take() {
+                    let chunk = data.chunk().to_owned(); // FIXME - avoid copy
+                    self.write_fut.set(async move {
+                        let ret = stream.write(&chunk).await;
+                        (stream, ret)
+                    });
+                }
+
+                let (stream, res) = ready!(self.write_fut.poll(cx));
+                self.stream = Some(stream);
+                match res {
+                    Ok(cnt) => data.advance(cnt),
+                    Err(err) => {
+                        return Poll::Ready(Err(SendStreamError::Write(err)));
+                    }
+                }
+            }
+        }
+        self.writing = None;
+        Poll::Ready(Ok(()))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn poll_finish(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(self.stream.as_mut().unwrap().finish().map_err(|e| e.into()))
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn reset(&mut self, reset_code: u64) {
+        let _ = self
+            .stream
+            .as_mut()
+            .unwrap()
+            .reset(VarInt::from_u64(reset_code).unwrap_or(VarInt::MAX));
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn send_data<D: Into<WriteBuf<B>>>(&mut self, data: D) -> Result<(), Self::Error> {
+        if self.writing.is_some() {
+            return Err(Self::Error::NotReady);
+        }
+        self.writing = Some(data.into());
+        Ok(())
+    }
+
+    #[instrument(skip_all, level = "trace")]
+    fn send_id(&self) -> StreamId {
+        self.stream
+            .as_ref()
+            .unwrap()
+            .id()
+            .0
+            .try_into()
+            .expect("invalid stream id")
+    }
+}
+
+impl<B> quic::SendStreamUnframed<B> for SendStream<B>
+where
+    B: Buf,
+{
+    #[instrument(skip_all, level = "trace")]
+    fn poll_send<D: Buf>(
+        &mut self,
+        cx: &mut task::Context<'_>,
+        buf: &mut D,
+    ) -> Poll<Result<usize, Self::Error>> {
+        if self.writing.is_some() {
+            // This signifies a bug in implementation
+            panic!("poll_send called while send stream is not ready")
+        }
+
+        let s = Pin::new(self.stream.as_mut().unwrap());
+
+        let res = ready!(s.poll_write(cx, buf.chunk()));
+        match res {
+            Ok(written) => {
+                buf.advance(written);
+                Poll::Ready(Ok(written))
+            }
+            Err(err) => Poll::Ready(Err(SendStreamError::Write(err))),
+        }
+    }
+}
+
+/// The error type for [`SendStream`]
+///
+/// Wraps errors that can happen writing to or polling a send stream.
+#[derive(Debug)]
+pub enum SendStreamError {
+    /// Errors when writing, wrapping a [`endpoint::WriteError`]
+    Write(WriteError),
+    /// Error when the stream is not ready, because it is still sending
+    /// data from a previous call
+    NotReady,
+    /// Error when the stream is closed
+    StreamClosed(ClosedStream),
+}
+
+impl From<SendStreamError> for std::io::Error {
+    fn from(value: SendStreamError) -> Self {
+        match value {
+            SendStreamError::Write(err) => err.into(),
+            SendStreamError::NotReady => {
+                std::io::Error::new(std::io::ErrorKind::Other, "send stream is not ready")
+            }
+            SendStreamError::StreamClosed(err) => err.into(),
+        }
+    }
+}
+
+impl std::error::Error for SendStreamError {}
+
+impl Display for SendStreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl From<WriteError> for SendStreamError {
+    fn from(e: WriteError) -> Self {
+        Self::Write(e)
+    }
+}
+
+impl From<ClosedStream> for SendStreamError {
+    fn from(value: ClosedStream) -> Self {
+        Self::StreamClosed(value)
+    }
+}
+
+impl Error for SendStreamError {
+    fn is_timeout(&self) -> bool {
+        matches!(
+            self,
+            Self::Write(endpoint::WriteError::ConnectionLost(
+                endpoint::ConnectionError::TimedOut
+            ))
+        )
+    }
+
+    fn err_code(&self) -> Option<u64> {
+        match self {
+            Self::Write(endpoint::WriteError::Stopped(error_code)) => Some(error_code.into_inner()),
+            Self::Write(endpoint::WriteError::ConnectionLost(
+                endpoint::ConnectionError::ApplicationClosed(ApplicationClose {
+                    error_code, ..
+                }),
+            )) => Some(error_code.into_inner()),
+            _ => None,
+        }
+    }
+}
+
+impl From<SendStreamError> for Arc<dyn Error> {
+    fn from(e: SendStreamError) -> Self {
+        Arc::new(e)
+    }
+}


### PR DESCRIPTION
This implements a low-level API from hyper which can be used directly.  It also includes primitive support for running an axum server.

The latter does some extra copies and puts too much in memory.  It should still be generalised into more generic hyper support with parametrised body etc.

This currently relies on a git reference to iroh-net.  The 0.28 iroh-net release should fix this, probably best to wait until that release to merge this so that this does not break CI for the other examples randomly as there's no Cargo.lock checked in.