### PR TITLE
Unbitrot the tracker

### DIFF
--- a/content-discovery/Cargo.toml
+++ b/content-discovery/Cargo.toml
@@ -31,8 +31,8 @@ iroh-base = "0.34"
 iroh-blobs = { version = "0.34", features = ["rpc"] }
 # explicitly specified until iroh minimal crates issues are solved, see https://github.com/n0-computer/iroh/pull/3255
 tokio = { version = "1.44.1" }
-mainline = { version = "2.0.0", default-features = false }
-pkarr = { version = "2.0.3", default-features = false }
+mainline = { version = "5.4.0", default-features = false }
+pkarr = { version = "3.7.0", default-features = false }
 postcard = { version = "1", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.13", default-features = false }
 anyhow = { version = "1", default-features = false }

--- a/content-discovery/Cargo.toml
+++ b/content-discovery/Cargo.toml
@@ -31,3 +31,9 @@ iroh-base = "0.34"
 iroh-blobs = { version = "0.34", features = ["rpc"] }
 # explicitly specified until iroh minimal crates issues are solved, see https://github.com/n0-computer/iroh/pull/3255
 tokio = { version = "1.44.1" }
+mainline = { version = "2.0.0", default-features = false }
+pkarr = { version = "2.0.3", default-features = false }
+postcard = { version = "1", default-features = false }
+quinn = { package = "iroh-quinn", version = "0.13", default-features = false }
+anyhow = { version = "1", default-features = false }
+flume = { version = "0.11" }

--- a/content-discovery/Cargo.toml
+++ b/content-discovery/Cargo.toml
@@ -37,3 +37,7 @@ postcard = { version = "1", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.13", default-features = false }
 anyhow = { version = "1", default-features = false }
 flume = { version = "0.11" }
+futures = { version = "0.3.25" }
+rcgen = { version = "0.13.1" }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+genawaiter = { version = "0.99.1", features = ["futures03"] }

--- a/content-discovery/Cargo.toml
+++ b/content-discovery/Cargo.toml
@@ -31,6 +31,7 @@ iroh-base = "0.34"
 iroh-blobs = { version = "0.34", features = ["rpc"] }
 # explicitly specified until iroh minimal crates issues are solved, see https://github.com/n0-computer/iroh/pull/3255
 tokio = { version = "1.44.1" }
+tokio-stream = { version = "0.1.17" }
 mainline = { version = "5.4.0", default-features = false }
 pkarr = { version = "3.7.0", default-features = false }
 postcard = { version = "1", default-features = false }

--- a/content-discovery/Cargo.toml
+++ b/content-discovery/Cargo.toml
@@ -37,7 +37,6 @@ pkarr = { version = "3.7.0", default-features = false }
 postcard = { version = "1", default-features = false }
 quinn = { package = "iroh-quinn", version = "0.13", default-features = false }
 anyhow = { version = "1", default-features = false }
-flume = { version = "0.11" }
 futures = { version = "0.3.25" }
 rcgen = { version = "0.13.1" }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/content-discovery/iroh-mainline-content-discovery-cli/Cargo.toml
+++ b/content-discovery/iroh-mainline-content-discovery-cli/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 iroh = { workspace = true }
 iroh-blobs = { workspace = true }
 iroh-mainline-content-discovery = { path = "../iroh-mainline-content-discovery" }
-mainline = { version = "2.0.0" }
+mainline = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
 futures = { version = "0.3.25" }
 clap = { version = "4", features = ["derive"] }

--- a/content-discovery/iroh-mainline-content-discovery-cli/Cargo.toml
+++ b/content-discovery/iroh-mainline-content-discovery-cli/Cargo.toml
@@ -12,7 +12,7 @@ iroh = { workspace = true }
 iroh-blobs = { workspace = true }
 iroh-mainline-content-discovery = { path = "../iroh-mainline-content-discovery" }
 mainline = { version = "2.0.0" }
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 futures = { version = "0.3.25" }
 clap = { version = "4", features = ["derive"] }
 tempfile = { version = "3.4" }

--- a/content-discovery/iroh-mainline-content-discovery-cli/src/main.rs
+++ b/content-discovery/iroh-mainline-content-discovery-cli/src/main.rs
@@ -106,8 +106,8 @@ async fn query(args: QueryArgs) -> anyhow::Result<()> {
             verified: args.verified,
         },
     };
-    let res = discovery.query(q).await?;
-    for sa in res {
+    let mut res = discovery.query(q).await?;
+    while let Some(sa) = res.recv().await {
         if sa.verify().is_ok() {
             println!("{}: {:?}", sa.announce.host, sa.announce.kind);
         } else {

--- a/content-discovery/iroh-mainline-content-discovery/Cargo.toml
+++ b/content-discovery/iroh-mainline-content-discovery/Cargo.toml
@@ -26,9 +26,9 @@ quinn = { workspace = true, optional = true }
 mainline = { workspace = true, optional = true, features = ["async"] }
 anyhow = { workspace = true, features = ["backtrace"], optional = true }
 postcard = { workspace = true, features = ["alloc", "use-std"], optional = true }
-futures = { version = "0.3.25", optional = true }
-rcgen = { version = "0.13.1", optional = true }
-rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
+futures = { workspace = true, optional = true }
+rcgen = { workspace = true, optional = true }
+rustls = { workspace = true, features = ["ring"], optional = true }
 genawaiter = { version = "0.99.1", features = ["futures03"], optional = true }
 tokio = { workspace = true, optional = true }
 flume = { workspace = true }

--- a/content-discovery/iroh-mainline-content-discovery/Cargo.toml
+++ b/content-discovery/iroh-mainline-content-discovery/Cargo.toml
@@ -31,7 +31,7 @@ rcgen = { workspace = true, optional = true }
 rustls = { workspace = true, features = ["ring"], optional = true }
 genawaiter = { version = "0.99.1", features = ["futures03"], optional = true }
 tokio = { workspace = true, optional = true }
-flume = { workspace = true }
+tokio-stream = { workspace = true }
 
 # dependencies for the tls utils
 der = { version = "0.7", features = ["alloc", "derive"], optional = true }

--- a/content-discovery/iroh-mainline-content-discovery/Cargo.toml
+++ b/content-discovery/iroh-mainline-content-discovery/Cargo.toml
@@ -22,16 +22,16 @@ hex = "0.4.3"
 
 # Optional features for the client functionality
 tracing = { version = "0.1", optional = true }
-quinn = { package = "iroh-quinn", version = "0.13", optional = true }
-mainline = { version = "2.0.0", optional = true, features = ["async"] }
-anyhow = { version = "1", features = ["backtrace"], optional = true }
-postcard = { version = "1", default-features = false, features = ["alloc", "use-std"], optional = true }
+quinn = { workspace = true, optional = true }
+mainline = { workspace = true, optional = true, features = ["async"] }
+anyhow = { workspace = true, features = ["backtrace"], optional = true }
+postcard = { workspace = true, features = ["alloc", "use-std"], optional = true }
 futures = { version = "0.3.25", optional = true }
 rcgen = { version = "0.13.1", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 genawaiter = { version = "0.99.1", features = ["futures03"], optional = true }
 tokio = { workspace = true, optional = true }
-flume = "0.11.0"
+flume = { workspace = true }
 
 # dependencies for the tls utils
 der = { version = "0.7", features = ["alloc", "derive"], optional = true }

--- a/content-discovery/iroh-mainline-content-discovery/src/client.rs
+++ b/content-discovery/iroh-mainline-content-discovery/src/client.rs
@@ -19,6 +19,7 @@ use iroh::{
     Endpoint, NodeId,
 };
 use iroh_blobs::HashAndFormat;
+use tokio::sync::mpsc;
 
 use crate::{
     protocol::{
@@ -423,13 +424,13 @@ where
 
 #[derive(Debug, Clone)]
 pub struct UdpDiscovery {
-    tx: flume::Sender<UdpActorMessage>,
+    tx: mpsc::Sender<UdpActorMessage>,
 }
 
 impl UdpDiscovery {
     /// Create a new UDP discovery service.
     pub async fn new(socket: SocketAddr) -> anyhow::Result<Self> {
-        let (tx, rx) = flume::unbounded();
+        let (tx, rx) = mpsc::channel(1024);
         let socket = tokio::net::UdpSocket::bind(socket).await?;
         let _task = tokio::spawn(
             UdpActor {
@@ -450,7 +451,7 @@ impl UdpDiscovery {
         dht: mainline::Dht,
         args: Query,
     ) -> anyhow::Result<impl Stream<Item = SignedAnnounce>> {
-        let results = self.query(args).await?.into_stream().boxed();
+        let results = tokio_stream::wrappers::ReceiverStream::new(self.query(args).await?).boxed();
         let dht = dht.as_async();
         let this = self.clone();
         let find_new_trackers = async move {
@@ -474,7 +475,7 @@ impl UdpDiscovery {
     pub async fn add_tracker(&self, tracker: SocketAddr) -> anyhow::Result<()> {
         Ok(self
             .tx
-            .send_async(UdpActorMessage::AddTracker { tracker })
+            .send(UdpActorMessage::AddTracker { tracker })
             .await?)
     }
 
@@ -482,22 +483,20 @@ impl UdpDiscovery {
     pub async fn remove_tracker(&self, tracker: SocketAddr) -> anyhow::Result<()> {
         Ok(self
             .tx
-            .send_async(UdpActorMessage::RemoveTracker { tracker })
+            .send(UdpActorMessage::RemoveTracker { tracker })
             .await?)
     }
 
-    pub async fn query(&self, query: Query) -> anyhow::Result<flume::Receiver<SignedAnnounce>> {
+    pub async fn query(&self, query: Query) -> anyhow::Result<mpsc::Receiver<SignedAnnounce>> {
         let (tx, rx) = oneshot::channel();
-        self.tx
-            .send_async(UdpActorMessage::Query { query, tx })
-            .await?;
+        self.tx.send(UdpActorMessage::Query { query, tx }).await?;
         Ok(rx.await?)
     }
 
     pub async fn announce_once(&self, announce: SignedAnnounce) -> anyhow::Result<()> {
         let (tx, rx) = oneshot::channel();
         self.tx
-            .send_async(UdpActorMessage::AnnounceOnce { announce, tx })
+            .send(UdpActorMessage::AnnounceOnce { announce, tx })
             .await?;
         rx.await?;
         Ok(())
@@ -514,7 +513,7 @@ impl UdpDiscovery {
         })
         .into();
         self.tx
-            .send_async(UdpActorMessage::StoreAnnounceTask { announce, task })
+            .send(UdpActorMessage::StoreAnnounceTask { announce, task })
             .await?;
         Ok(())
     }
@@ -522,9 +521,9 @@ impl UdpDiscovery {
 
 struct UdpActor {
     socket: tokio::net::UdpSocket,
-    rx: flume::Receiver<UdpActorMessage>,
+    rx: mpsc::Receiver<UdpActorMessage>,
     trackers: BTreeSet<SocketAddr>,
-    listeners: BTreeMap<Query, Vec<flume::Sender<SignedAnnounce>>>,
+    listeners: BTreeMap<Query, Vec<mpsc::Sender<SignedAnnounce>>>,
     announces: BTreeMap<(HashAndFormat, AnnounceKind), AbortingJoinHandle<()>>,
 }
 
@@ -548,7 +547,7 @@ impl<T> Drop for AbortingJoinHandle<T> {
 enum UdpActorMessage {
     Query {
         query: Query,
-        tx: oneshot::Sender<flume::Receiver<SignedAnnounce>>,
+        tx: oneshot::Sender<mpsc::Receiver<SignedAnnounce>>,
     },
     AddTracker {
         tracker: SocketAddr,
@@ -572,11 +571,11 @@ impl UdpActor {
         let mut buf = [0u8; MAX_MSG_SIZE];
         loop {
             tokio::select! {
-                msg = self.rx.recv_async() => {
+                msg = self.rx.recv() => {
                     tracing::trace!("got msg {:?}", msg);
                     match msg {
-                        Ok(UdpActorMessage::Query { query, tx  }) => {
-                            let (announce_tx, announce_rx) = flume::bounded(1024);
+                        Some(UdpActorMessage::Query { query, tx  }) => {
+                            let (announce_tx, announce_rx) = mpsc::channel(1024);
                             self.listeners.entry(query).or_default().push(announce_tx);
                             let msg = Request::Query(query);
                             let msg = postcard::to_slice(&msg, &mut buf).unwrap();
@@ -586,7 +585,7 @@ impl UdpActor {
                             }
                             tx.send(announce_rx).ok();
                         }
-                        Ok(UdpActorMessage::AddTracker { tracker }) => {
+                        Some(UdpActorMessage::AddTracker { tracker }) => {
                             if self.trackers.insert(tracker) {
                                 for query in self.listeners.keys() {
                                     let msg = Request::Query(*query);
@@ -595,21 +594,21 @@ impl UdpActor {
                                 }
                             }
                         }
-                        Ok(UdpActorMessage::RemoveTracker { tracker }) => {
+                        Some(UdpActorMessage::RemoveTracker { tracker }) => {
                             self.trackers.remove(&tracker);
                         }
-                        Ok(UdpActorMessage::StoreAnnounceTask { announce, task }) => {
+                        Some(UdpActorMessage::StoreAnnounceTask { announce, task }) => {
                             let key = (announce.announce.content, announce.announce.kind);
                             self.announces.insert(key, task);
                         }
-                        Ok(UdpActorMessage::AnnounceOnce { announce, tx }) => {
+                        Some(UdpActorMessage::AnnounceOnce { announce, tx }) => {
                             let msg = postcard::to_slice(&Request::Announce(announce), &mut buf).unwrap();
                             for tracker in &self.trackers {
                                 self.socket.send_to(msg, tracker).await.ok();
                             }
                             tx.send(()).ok();
                         }
-                        Err(flume::RecvError::Disconnected) => break,
+                        None => break,
                     }
                 },
                 res = self.socket.recv_from(&mut buf) => {
@@ -642,7 +641,7 @@ impl UdpActor {
                                         }
                                         let mut to_remove = Vec::new();
                                         for (i, sender) in senders.iter().enumerate() {
-                                            if sender.send_async(sa).await.is_err() {
+                                            if sender.send(sa).await.is_err() {
                                                 to_remove.push(i);
                                             }
                                         }

--- a/content-discovery/iroh-mainline-tracker/Cargo.toml
+++ b/content-discovery/iroh-mainline-tracker/Cargo.toml
@@ -38,7 +38,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ttl_cache = "0.5.1"
 url = "2.5.0"
-flume = { workspace = true }
 genawaiter = { version = "0.99.1", features = ["futures03"] }
 iroh-mainline-content-discovery = { path = "../iroh-mainline-content-discovery", features = ["client"] }
 quinn = { workspace = true }

--- a/content-discovery/iroh-mainline-tracker/Cargo.toml
+++ b/content-discovery/iroh-mainline-tracker/Cargo.toml
@@ -21,7 +21,7 @@ humantime = "2.1.0"
 iroh = { workspace = true }
 iroh-blobs = { workspace = true }
 mainline = { workspace = true, features = ["async"] }
-pkarr = { workspace = true, features = ["async"] }
+pkarr = { workspace = true }
 postcard = { workspace = true, features = ["alloc", "use-std"] }
 rand = "0.8"
 rcgen = "0.12.0"

--- a/content-discovery/iroh-mainline-tracker/Cargo.toml
+++ b/content-discovery/iroh-mainline-tracker/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # needs to keep updated with the dep of iroh-blobs
 bao-tree = { version = "0.13", features = ["tokio_fsm"], default-features = false }
 bytes = "1"
@@ -20,9 +20,9 @@ hex = "0.4.3"
 humantime = "2.1.0"
 iroh = { workspace = true }
 iroh-blobs = { workspace = true }
-mainline = { version = "2.0.0", features = ["async"] }
-pkarr = { version = "2.0.3", features = ["async"] }
-postcard = { version = "1", default-features = false, features = ["alloc", "use-std"] }
+mainline = { workspace = true, features = ["async"] }
+pkarr = { workspace = true, features = ["async"] }
+postcard = { workspace = true, features = ["alloc", "use-std"] }
 rand = "0.8"
 rcgen = "0.12.0"
 redb = "1.5.0"
@@ -38,10 +38,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ttl_cache = "0.5.1"
 url = "2.5.0"
-flume = "0.11.0"
+flume = { workspace = true }
 genawaiter = { version = "0.99.1", features = ["futures03"] }
 iroh-mainline-content-discovery = { path = "../iroh-mainline-content-discovery", features = ["client"] }
-quinn = { package = "iroh-quinn", version = "0.13" }
+quinn = { workspace = true }
 
 clap = { version = "4", features = ["derive"], optional = true }
 serde-big-array = "0.5.1"

--- a/content-discovery/iroh-mainline-tracker/src/tracker.rs
+++ b/content-discovery/iroh-mainline-tracker/src/tracker.rs
@@ -792,7 +792,7 @@ impl Tracker {
         };
         txn.commit()?;
         let rt = tokio::runtime::Handle::current();
-        let handle = std::thread::spawn(move|| {
+        let handle = std::thread::spawn(move || {
             rt.block_on(async move {
                 if let Err(cause) = actor.run(db).await {
                     tracing::error!("error in actor: {}", cause);
@@ -974,7 +974,11 @@ impl Tracker {
                 let response = self.handle_query(query).await?;
                 let response = Response::QueryResponse(response);
                 let response_bytes = postcard::to_slice(&response, &mut buf)?;
-                trace!("sending response, {:?} {} bytes", response, response_bytes.len());
+                trace!(
+                    "sending response, {:?} {} bytes",
+                    response,
+                    response_bytes.len()
+                );
                 socket.send_to(response_bytes, addr).await?;
             }
         }

--- a/content-discovery/iroh-mainline-tracker/src/tracker.rs
+++ b/content-discovery/iroh-mainline-tracker/src/tracker.rs
@@ -79,7 +79,7 @@ impl Drop for Inner {
             drop_permit.send(ActorMessage::Stop);
         }
         if let Some(handle) = self.handle.take() {
-            if let Err(_) = handle.join() {
+            if handle.join().is_err() {
                 error!("error joining actor thread");
             }
         }

--- a/content-discovery/iroh-mainline-tracker/src/tracker/util.rs
+++ b/content-discovery/iroh-mainline-tracker/src/tracker/util.rs
@@ -1,15 +1,15 @@
-use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
 
 /// A wrapper for a flume receiver that allows peeking at the next message.
 #[derive(Debug)]
-pub(super) struct PeekableFlumeReceiver<T> {
+pub(super) struct PeekableReceiver<T> {
     msg: Option<T>,
-    recv: flume::Receiver<T>,
+    recv: mpsc::Receiver<T>,
 }
 
 #[allow(dead_code)]
-impl<T> PeekableFlumeReceiver<T> {
-    pub fn new(recv: flume::Receiver<T>) -> Self {
+impl<T> PeekableReceiver<T> {
+    pub fn new(recv: mpsc::Receiver<T>) -> Self {
         Self { msg: None, recv }
     }
 
@@ -17,9 +17,9 @@ impl<T> PeekableFlumeReceiver<T> {
     ///
     /// Will block if there are no messages.
     /// Returns None only if there are no more messages (sender is dropped).
-    pub fn peek(&mut self) -> Option<&T> {
+    pub async fn peek(&mut self) -> Option<&T> {
         if self.msg.is_none() {
-            self.msg = self.recv.recv().ok();
+            self.msg = self.recv.recv().await;
         }
         self.msg.as_ref()
     }
@@ -28,46 +28,11 @@ impl<T> PeekableFlumeReceiver<T> {
     ///
     /// Will block if there are no messages.
     /// Returns None only if there are no more messages (sender is dropped).
-    pub fn recv(&mut self) -> Option<T> {
+    pub async fn recv(&mut self) -> Option<T> {
         if let Some(msg) = self.msg.take() {
             return Some(msg);
         }
-        self.recv.recv().ok()
-    }
-
-    /// Try to peek at the next message.
-    ///
-    /// Will not block.
-    /// Returns None if reading would block, or if there are no more messages (sender is dropped).
-    pub fn try_peek(&mut self) -> Option<&T> {
-        if self.msg.is_none() {
-            self.msg = self.recv.try_recv().ok();
-        }
-        self.msg.as_ref()
-    }
-
-    /// Try to receive the next message.
-    ///
-    /// Will not block.
-    /// Returns None if reading would block, or if there are no more messages (sender is dropped).
-    pub fn try_recv(&mut self) -> Option<T> {
-        if let Some(msg) = self.msg.take() {
-            return Some(msg);
-        }
-        self.recv.try_recv().ok()
-    }
-
-    pub fn recv_timeout(&mut self, timeout: std::time::Duration) -> Option<T> {
-        if let Some(msg) = self.msg.take() {
-            return Some(msg);
-        }
-        self.recv.recv_timeout(timeout).ok()
-    }
-
-    /// Create an iterator that pulls messages from the receiver for at most
-    /// `count` messages or `max_duration` time.
-    pub fn batch_iter(&mut self, count: usize, max_duration: Duration) -> BatchIter<T> {
-        BatchIter::new(self, count, max_duration)
+        self.recv.recv().await
     }
 
     /// Push back a message. This will only work if there is room for it.
@@ -79,40 +44,5 @@ impl<T> PeekableFlumeReceiver<T> {
         } else {
             Err(msg)
         }
-    }
-}
-
-pub(super) struct BatchIter<'a, T> {
-    recv: &'a mut PeekableFlumeReceiver<T>,
-    start: Instant,
-    remaining: usize,
-    max_duration: Duration,
-}
-
-impl<'a, T> BatchIter<'a, T> {
-    fn new(recv: &'a mut PeekableFlumeReceiver<T>, count: usize, max_duration: Duration) -> Self {
-        Self {
-            recv,
-            start: Instant::now(),
-            remaining: count,
-            max_duration,
-        }
-    }
-}
-
-impl<T> Iterator for BatchIter<'_, T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining == 0 {
-            return None;
-        }
-        let elapsed = self.start.elapsed();
-        if elapsed >= self.max_duration {
-            return None;
-        }
-        let remaining_time = self.max_duration - elapsed;
-        self.remaining -= 1;
-        self.recv.recv_timeout(remaining_time)
     }
 }


### PR DESCRIPTION
- Update mainline and pkarr to the latest versions
- Fix endpoint setup so that it discovers nodes again
- Use workspace deps
- Replace flume with tokio::mpsc
- Async on a dedicated io thread donated to the tokio runtime