### PR TITLE
chore: Release content-discovery and content-discovery-cli 0.2.0

### DIFF
--- a/content-discovery/Cargo.lock
+++ b/content-discovery/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-content-discovery"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "derive_more 1.0.0",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-content-discovery-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-content-tracker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bao-tree",

--- a/content-discovery/iroh-content-discovery-cli/Cargo.toml
+++ b/content-discovery/iroh-content-discovery-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-content-discovery-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Content discovery for iroh, using a simple tracker protocol"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 iroh = { workspace = true }
 iroh-blobs = { workspace = true }
-iroh-content-discovery = { path = "../iroh-content-discovery", version = "0.1.0" }
+iroh-content-discovery = { path = "../iroh-content-discovery", version = "0.2.0" }
 anyhow = { workspace = true, features = ["backtrace"] }
 futures = { version = "0.3.25" }
 clap = { version = "4", features = ["derive"] }

--- a/content-discovery/iroh-content-discovery/Cargo.toml
+++ b/content-discovery/iroh-content-discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-content-discovery"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Content discovery for iroh, using a simple tracker protocol"
 license = "MIT OR Apache-2.0"

--- a/content-discovery/iroh-content-tracker/Cargo.toml
+++ b/content-discovery/iroh-content-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-content-tracker"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Content tracker for iroh, using a simple tracker protocol"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
To be used from https://github.com/rklaehn/iroh-workshop-web3summit2025 etc.