### PR TITLE
chore: upgrade to latest `iroh`, `iroh-blobs`, `iroh-gossip` and `iroh-tickets`

### DIFF
--- a/h3-iroh/Cargo.toml
+++ b/h3-iroh/Cargo.toml
@@ -15,8 +15,8 @@ http-body = { version = "1", optional = true }
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.5", optional = true }
 hyper-util = { version = "0.1", optional = true }
-iroh = "0.94"
-iroh-tickets = "0.1"
+iroh = "0.95"
+iroh-tickets = "0.2"
 tokio = { version = "1", features = ["io-util"], default-features = false}
 tokio-util = "0.7"
 tower = { version = "0.5", optional = true }

--- a/iroh-dag-sync/Cargo.toml
+++ b/iroh-dag-sync/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-iroh-blobs = "0.96"
-iroh-gossip = "0.94"
-iroh = "0.94"
-iroh-tickets = "0.1"
+iroh-blobs = "0.97"
+iroh-gossip = "0.95"
+iroh = "0.95"
+iroh-tickets = "0.2"
 iroh-car = "0.5"
 redb = "2.6"
 clap = { version = "4.5.7", features = ["derive"] }
@@ -19,7 +19,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 futures-lite = "2.3.0"
 iroh-io = "0.6"
 tokio-util = { version = "0.7.11", features = ["rt"] }
-bao-tree = "0.15.1"
+bao-tree = "0.16.0"
 genawaiter = "0.99.1"
 bytes = "1.6.0"
 hex = "0.4.3"

--- a/iroh-dag-sync/src/sync.rs
+++ b/iroh-dag-sync/src/sync.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use bao_tree::{io::outboard::EmptyOutboard, BaoTree, ChunkRanges};
-use iroh::endpoint::{Connecting, RecvStream, SendStream};
+use iroh::endpoint::{Accepting, RecvStream, SendStream};
 use iroh_blobs::store::{fs::FsStore, IROH_BLOCK_SIZE};
 use iroh_io::{TokioStreamReader, TokioStreamWriter};
 use multihash_codetable::MultihashDigest;
@@ -15,15 +15,15 @@ use crate::{
 const MAX_REQUEST_SIZE: usize = 1024 * 1024 * 16;
 
 pub async fn handle_request(
-    mut connecting: Connecting,
+    mut accepting: Accepting,
     tables: &impl ReadableTables,
     blobs: &FsStore,
 ) -> anyhow::Result<()> {
     tracing::info!(
-        "got connecting, {:?}",
-        std::str::from_utf8(&connecting.alpn().await?)
+        "got accepting, {:?}",
+        std::str::from_utf8(&accepting.alpn().await?)
     );
-    let connection = connecting.await?;
+    let connection = accepting.await?;
     tracing::info!("got connection, waiting for request");
     let (mut send, mut recv) = connection.accept_bi().await?;
     tracing::info!("got request stream");

--- a/iroh-pkarr-naming-system/Cargo.toml
+++ b/iroh-pkarr-naming-system/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.79"
 derive_more = "2.0"
-iroh = "0.94"
-iroh-blobs = "0.96"
+iroh = "0.95"
+iroh-blobs = "0.97"
 pkarr = { version = "5", features = ["dht"] }
 tokio = "1.35.1"
 tokio-util = "0.7.12"


### PR DESCRIPTION
Skips `s3-bao-store` which needs additional changes from `iroh-blobs` before it can be updated

Skips `content-discovery` for now, since it needs a bit more thought to adapt for the new 0-rtt api